### PR TITLE
Persisting data in Tracker, remove peer when they disconnect

### DIFF
--- a/code-collab-app/src/editorpage.js
+++ b/code-collab-app/src/editorpage.js
@@ -11,11 +11,6 @@ import { inject, observer } from 'mobx-react';
 class Editorpage extends React.Component {
   constructor(props){
     super(props);
-
-    this.state = {
-      cellText: this.props.peer_data.doc_data,
-      cellLocked: this.props.peer_data.cell_locked,
-    }
   }
 
   componentDidMount() {
@@ -36,14 +31,13 @@ class Editorpage extends React.Component {
   // key: the index of the cell to lock
   lockEditorCell = (key) => {
     // Lock cell so user may not edit
-    this.props.peer_data.set_cell_locked(key, true);
+    this.props.peer_data.cell_locked[key] = true;
   }
 
   // Unlock a cell so the user may edit it
   // key: the index of the cell to unlock
   unlockEditorCell = (key) => {
-    this.props.peer_data.set_cell_locked(key, false);
-
+    this.props.peer_data.cell_locked[key] = false;
   }
 
   // Requests lock on cell from all peers in session
@@ -74,7 +68,7 @@ class Editorpage extends React.Component {
     const lockApproved = this.requestEditorCellLock(key);
     if (lockApproved === false) return;
     // Remember the cell currently being edited
-    this.props.peer_data.set_current_cell(key);
+    this.props.peer_data.current_cell = key;
   }
 
   // Event handler for cursor leaving a cell. Broadcasts update for that cell and releases lock.
@@ -83,14 +77,14 @@ class Editorpage extends React.Component {
   leaveCellEvent = (e) => {
     e.preventDefault();
     // Get index of last cell edited
-    const lastCellEdited = this.props.peer_data.get_current_cell();
+    const lastCellEdited = this.props.peer_data.current_cell;
     if (lastCellEdited === null) return;
 
     // Broadcast updates to cell just released from editing
     this.broadcastCellUpdate(lastCellEdited);
 
     // Reset cell last edited state
-    this.props.peer_data.set_current_cell(null);
+    this.props.peer_data.current_cell = null;
   }
 
   // Event handler for button click to add new blank editor cell.
@@ -108,7 +102,7 @@ class Editorpage extends React.Component {
     }
 
     let cellLabel = "Cell " + keyvalue.toString();
-    let disableCell = this.state.cellLocked[keyvalue];
+    let disableCell = this.props.peer_data.cell_locked[keyvalue];
     let textProps = {
       style: {
         color: 'white'
@@ -133,7 +127,7 @@ class Editorpage extends React.Component {
         onBlur={(e) => this.leaveCellEvent(e)} // When cursor leaves cell
         fullWidth
         disabled={disableCell}
-        value={this.state.cellText[keyvalue]}
+        value={this.props.peer_data.doc_data[keyvalue]}
         variant="filled"
         InputLabelProps={{
           style: {
@@ -142,7 +136,7 @@ class Editorpage extends React.Component {
         }}
         InputProps={textProps}
         onChange={(event) => {
-          this.props.peer_data.update_existing_cell(keyvalue, event.target.value);
+          this.props.peer_data.doc_data[keyvalue] = event.target.value;
         }}
       />
       );
@@ -157,7 +151,7 @@ class Editorpage extends React.Component {
         <body className="App-editor">
           <div className="box-container">
             {
-              this.state.cellText.map((cellContents, index) => (
+              this.props.peer_data.doc_data.map((cellContents, index) => (
                 <React.Fragment key={index}>
                   { this.renderTextbox(index, cellContents) }
                 </React.Fragment>))

--- a/code-collab-app/src/homepage.js
+++ b/code-collab-app/src/homepage.js
@@ -13,13 +13,13 @@ class Homepage extends React.Component {
   }
 
   handleJoinSession(session_info) {
-    this.props.peer_data.reset();
+    this.props.peer_data.reset(session_info.id);
     this.props.peer_data.join_session(session_info.document_name, session_info.id);
     this.props.history.push({pathname: '/editor'});
   }
 
   handleNewSession() {
-    this.props.peer_data.reset();
+    this.props.peer_data.reset(null);
     // TODO: Dynamically set session name (get from user?)
     this.props.peer_data.create_new_session('New Session');
     this.props.history.push({pathname: '/editor'});

--- a/tracker/data/bVNocbRzv.json
+++ b/tracker/data/bVNocbRzv.json
@@ -1,1 +1,1 @@
-{"id":"bVNocbRzv","document_name":"Test","peers":["288c036c-3e41-4049-80c4-31bdc047c1a3"],"data":[]}
+{"id":"bVNocbRzv","document_name":"Data","peers":[],"data":["Hello World!","Got data from tracker"]}

--- a/tracker/data/kdTCxoens.json
+++ b/tracker/data/kdTCxoens.json
@@ -1,1 +1,1 @@
-{"id":"kdTCxoens","document_name":"Test","peers":["01631122-45df-4846-a429-fffcc585eb7a"],"data":[]}
+{"id":"kdTCxoens","document_name":"Test","peers":[],"data":[]}

--- a/tracker/index.js
+++ b/tracker/index.js
@@ -22,6 +22,7 @@ peerServer.on('connection', peer => {
 });
 
 peerServer.on('disconnect', peer => {
+  peerRoute.removePeer(peer.id);
   console.log('\nlost peerjs connection: ' + peer.id);
 });
 
@@ -58,7 +59,11 @@ io.on("connection", peer => {
   // Get document data request
   peer.on('get_doc_req', session_id => {
     const document = peerRoute.getDocument(session_id)
-    socket.emit('get_doc_res', { doc: document });
+    peer.emit('get_doc_res', { doc: document });
+  });
+
+  peer.on('cell_update', data => {
+    peerRoute.updateSessionData(data.session_id, data.index, data.value);
   });
 
   peer.on("disconnect", () => console.log("lost socket.io connection " + peer.id));

--- a/tracker/routes/peerRoute.js
+++ b/tracker/routes/peerRoute.js
@@ -41,17 +41,23 @@ const addPeer = (sessionID, newPeer) => {
         return;
     }
     sessions[sessionID].peers.push(newPeer);
+
+    // persisting the change to the disk
+    writeToFile(sessionID, sessions[sessionID]);
     return sessions[sessionID].peers;
 }
 
-const removePeer = (sessionID, peer) => {
-    // If the session doesn't exist
-    if (!sessions[sessionID]) {
-        console.error('Remove peer failed for session ' + sessionID + '.',
-            'Session ' + sessionID + ' does not exist. Create it with the "new_session" event before trying to modify it.');
-        return;
+const removePeer = (peerId) => {
+    // Iterate over the sessions and find out which session the peer is in and remove the peer from that
+    for(sessionId in sessions){
+        if(sessions[sessionId].peers.includes(peerId)){
+            sessions[sessionId].peers = sessions[sessionId].peers.filter(peer => peerId !== peer);
+            
+            // persisting the change to the disk
+            writeToFile(sessionId, sessions[sessionId]);
+            break;
+        }
     }
-    sessions[sessionID].peers = sessions[sessionID].peers.filter(peer => newPeer !== peer);
 }
 
 const getSessionList = () => {
@@ -78,6 +84,11 @@ const getDocument = (sessionID) => {
     return sessions[sessionID].data;
 }
 
+const updateSessionData = (sessionID, index, value) => {
+    sessions[sessionID].data[index] = value;
+    writeToFile(sessionID, sessions[sessionID]);
+}
+
 module.exports = {
     loadSessions,
     saveSession,
@@ -85,5 +96,6 @@ module.exports = {
     addPeer,
     removePeer,
     getSessionList,
-    getDocument
+    getDocument,
+    updateSessionData
 }


### PR DESCRIPTION
- Restrict resetting peer_data values unless the user switched to different session
- Sending Tracker document updates whenever a cell's value changes
- Removing a peer from Tracker's session's peer list when they disconnect or moved to a different session
- Bug fixes: Removed state variables from editor page, using data directly from peer_data store and clean up the extra getters and setters in peer_data

Next to come(in a different pull request): 
- Implement lock and unlock features