### PR TITLE
lock and unlock cell

### DIFF
--- a/code-collab-app/src/editorpage.js
+++ b/code-collab-app/src/editorpage.js
@@ -8,10 +8,10 @@ import IconButton from '@material-ui/core/IconButton';
 import AddIcon from '@material-ui/icons/Add';
 import { inject, observer } from 'mobx-react';
 
+const UNLOCK_CELL = 'unlock_cell';
+const LOCK_CELL = 'lock_cell';
+
 class Editorpage extends React.Component {
-  constructor(props){
-    super(props);
-  }
 
   componentDidMount() {
     this.props.peer_data.listen_for_req();
@@ -25,28 +25,6 @@ class Editorpage extends React.Component {
     }
     // peer_data updates the locked value, count and updates other peers
     this.props.peer_data.add_new_cell(cellContents);
-  }
-
-  // Locks a cell so the user cannot edit it
-  // key: the index of the cell to lock
-  lockEditorCell = (key) => {
-    // Lock cell so user may not edit
-    this.props.peer_data.cell_locked[key] = true;
-  }
-
-  // Unlock a cell so the user may edit it
-  // key: the index of the cell to unlock
-  unlockEditorCell = (key) => {
-    this.props.peer_data.cell_locked[key] = false;
-  }
-
-  // Requests lock on cell from all peers in session
-  // key: index of cell
-  requestEditorCellLock = (key) => {
-    // TODO - implement socket.io request to lock this cell on all other peers in session
-    // Will probably involve calling lockEditorCell()
-    console.log('Requesting cell lock from all peers for cell ' + key);
-    return true;
   }
 
   // Broadcast cell update and release lock for all other peers in session
@@ -64,9 +42,10 @@ class Editorpage extends React.Component {
   // key: index of cell
   selectCellEvent = (e, key) => {
     e.preventDefault();
+    
     // Request lock on cell from all peers
-    const lockApproved = this.requestEditorCellLock(key);
-    if (lockApproved === false) return;
+    this.props.peer_data.update_cell_lock(key, LOCK_CELL);
+
     // Remember the cell currently being edited
     this.props.peer_data.current_cell = key;
   }
@@ -85,6 +64,9 @@ class Editorpage extends React.Component {
 
     // Reset cell last edited state
     this.props.peer_data.current_cell = null;
+
+    // unlock the cell
+    this.props.peer_data.update_cell_lock(lastCellEdited, UNLOCK_CELL);
   }
 
   // Event handler for button click to add new blank editor cell.
@@ -112,7 +94,7 @@ class Editorpage extends React.Component {
       textProps = {
         style: {
           color: 'white',
-          background: '#de5246'
+          backgroundColor: '#de5246',
         }
       }
     }

--- a/code-collab-app/src/editorpage.js
+++ b/code-collab-app/src/editorpage.js
@@ -35,6 +35,12 @@ class Editorpage extends React.Component {
     // Will probably involve calling unlockEditorCell()
     // call method from peer_data to update other peers // sending updates
     this.props.peer_data.send_cell_update(key);
+
+    // Reset cell last edited state
+    this.props.peer_data.current_cell = null;
+
+    // unlock the cell
+    this.props.peer_data.update_cell_lock(key, UNLOCK_CELL);    
   }
 
   // Event handler for cursor entering a cell. Requests a lock on the cell from all peers.
@@ -61,12 +67,6 @@ class Editorpage extends React.Component {
 
     // Broadcast updates to cell just released from editing
     this.broadcastCellUpdate(lastCellEdited);
-
-    // Reset cell last edited state
-    this.props.peer_data.current_cell = null;
-
-    // unlock the cell
-    this.props.peer_data.update_cell_lock(lastCellEdited, UNLOCK_CELL);
   }
 
   // Event handler for button click to add new blank editor cell.

--- a/code-collab-app/src/storage/peer_data.js
+++ b/code-collab-app/src/storage/peer_data.js
@@ -5,6 +5,8 @@ import io from 'socket.io-client';
 const GET_DOC_REQ = 'get_doc_req';
 const GET_DOC_RES = 'get_doc_res';
 const CELL_UPDATE = 'cell_update';
+const UNLOCK_CELL = 'unlock_cell';
+const LOCK_CELL = 'lock_cell';
 
 // Tracker server config for peerjs
 const config = {
@@ -28,6 +30,7 @@ const peer_data = observable({
     current_cell: null,
     cell_count: 0,
     cell_locked: [],
+    cell_lock_time: null,
 
     initialize() {
         // will change later, hard coded for now
@@ -53,7 +56,8 @@ const peer_data = observable({
             this.request_doc_data();
         });
         this.tracker.on(GET_DOC_RES, data => {
-            this.doc_data.push(...data.doc);
+            this.cell_locked = Array(data.doc.length).fill(false);
+            this.doc_data = [...data.doc];
         });
     },
 
@@ -193,19 +197,49 @@ const peer_data = observable({
             console.log('received a get doc data request from another peer, sending data...');
             dataConnection.send({
                 message_type: GET_DOC_RES,
-                content: this.doc_data
+                content: {
+                    doc_data: [...this.doc_data],
+                    cell_locked: [...this.cell_locked],
+                }
             });
         }
         // Received a get doc response
         else if(data.message_type && data.message_type === GET_DOC_RES && data.content){
             console.log('received doc data from another peer');
-            this.doc_data.push(...data.content);
+            this.cell_locked.push(...data.content.cell_locked);
+            this.doc_data.push(...data.content.doc_data);
         }
         // Received a cell update
         else if(data.message_type && data.message_type === CELL_UPDATE && data.content){
-                if(data.content.index >= 0){
-                    this.doc_data[data.content.index] = data.content.value;
+            if(data.content.index >= 0){
+                // if it's a new cell, insert a cell locked value to false
+                if(data.content.index >= this.cell_locked.length){
+                    this.cell_locked.push(false);
                 }
+                this.doc_data[data.content.index] = data.content.value;
+            }
+        }
+        // Received msg to unlock a cell
+        else if(data.message_type && data.message_type === UNLOCK_CELL){
+            if(data.content.index >= 0){
+                this.cell_locked[data.content.index] = false;
+            }
+        }
+        // Received msg to lock a cell
+        else if(data.message_type && data.message_type === LOCK_CELL){
+            if(data.content.index >= 0){
+                // we lock if we are not working on anything or we are working on a different cell
+                if(this.current_cell === null || (this.current_cell && this.current_cell !== data.content.index)){
+                    this.cell_locked[data.content.index] = true;
+                }
+                // we also lock if we are working on something that the other peer requested first
+                else if(this.current_cell && this.current_cell === data.content.index && this.cell_lock_time > data.content.time){
+                    this.cell_locked[data.content.index] = true;
+                    this.current_cell = null;
+                    this.cell_lock_time = null;
+                }
+                // otherwise ignore the request, because we requested this cell first
+            }
         }
         else{
             // TODO -- do something more with this data
@@ -229,8 +263,8 @@ const peer_data = observable({
     },
 
     add_new_cell(cell_contents){
-        this.doc_data.push(cell_contents);
         this.cell_locked.push(false);
+        this.doc_data.push(cell_contents);
         this.increment_cell_count();
         this.send_cell_update(this.doc_data.length - 1);
     },
@@ -263,6 +297,22 @@ const peer_data = observable({
         );
     },
 
+    update_cell_lock(key, msg_type){
+        this.cell_lock_time = msg_type === LOCK_CELL ? new Date().getTime() : null;
+        if(this.session_peers_conn !== null){
+            this.session_peers_conn.forEach(peer_conn => {
+                peer_conn.send({
+                    message_type: msg_type, 
+                    content: {
+                        index: key,
+                        time: this.cell_lock_time
+                    }
+                });
+            })
+        }  
+    },
+
+    
 },
 {
     initialize: action,
@@ -271,6 +321,7 @@ const peer_data = observable({
     upload_document: action,
     add_new_cell: action,
     send_cell_update: action,
+    update_cell_lock: action,
 });
 
 export default peer_data;

--- a/code-collab-app/src/storage/peer_data.js
+++ b/code-collab-app/src/storage/peer_data.js
@@ -234,9 +234,9 @@ const peer_data = observable({
                 }
                 // we also lock if we are working on something that the other peer requested first
                 else if(this.current_cell && this.current_cell === data.content.index && this.cell_lock_time > data.content.time){
-                    this.cell_locked[data.content.index] = true;
                     this.current_cell = null;
                     this.cell_lock_time = null;
+                    this.cell_locked[data.content.index] = true;
                 }
                 // otherwise ignore the request, because we requested this cell first
             }


### PR DESCRIPTION
Lock and unlock  a cell
- When an user enters a cell, a message is sent to all its peers telling them to lock the cell. The message contains the index of the cell and time the lock was requested. Receiving peers will lock the cell if they are not working in the same cell, or they are working in the same cell but their requested time stamp is higher. If a peer requested the same cell first, then it just ignores the lock request. 
- When a user leaves a cell, a message is sent to all its peers telling them to unlock the cell. The message contains the index of the cell. 

Also fixed some bugs to make sure the disable cell style works. 